### PR TITLE
fix docker cred

### DIFF
--- a/root/.chezmoiexternal.yaml
+++ b/root/.chezmoiexternal.yaml
@@ -64,7 +64,8 @@
 
 "usr/local/share/gcm-core":
   type: archive
-  url: "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v{{ template "get-github-latest-version" list "GitCredentialManager/git-credential-manager" $cache }}/gcm-win-x86-{{ template "get-github-latest-version" list "GitCredentialManager/git-credential-manager" $cache }}.zip"
+  # https://github.com/GitCredentialManager/git-credential-manager/issues/869
+  url: "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v2.0.696/gcmcore-win-x86-2.0.696.zip"
   exact: true
 {{ else }}
 "usr/local/share/gcm-core":

--- a/root/.chezmoiexternal.yaml
+++ b/root/.chezmoiexternal.yaml
@@ -59,7 +59,7 @@
 {{ if .is_wsl }}
 "usr/bin/docker-credential-wincred.exe":
   type: file
-  url: "https://github.com/docker/docker-credential-helpers/releases/download/v0.6.4/docker-credential-wincred-v0.6.4-{{ .chezmoi.arch }}.zip"
+  url: "https://github.com/docker/docker-credential-helpers/releases/download/v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}/docker-credential-wincred-v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}-{{ .chezmoi.arch }}.zip"
   # This is needed because the binary inside of the archive does not come with execution permission by default
   executable: true
   filter:
@@ -78,7 +78,7 @@
 {{   if .is_gnome }}
 "usr/bin":
   type: archive
-  url: "https://github.com/docker/docker-credential-helpers/releases/download/v0.6.4/docker-credential-secretservice-v0.6.4-{{ .chezmoi.arch }}.tar.gz"
+  url: "https://github.com/docker/docker-credential-helpers/releases/download/v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}/docker-credential-secretservice-v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}-{{ .chezmoi.arch }}.tar.gz"
   include:
     - docker-credential-secretservice
 {{   end }}

--- a/root/.chezmoiexternal.yaml
+++ b/root/.chezmoiexternal.yaml
@@ -59,11 +59,8 @@
 {{ if .is_wsl }}
 "usr/bin/docker-credential-wincred.exe":
   type: file
-  url: "https://github.com/docker/docker-credential-helpers/releases/download/v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}/docker-credential-wincred-v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}-{{ .chezmoi.arch }}.zip"
-  # This is needed because the binary inside of the archive does not come with execution permission by default
+  url: "https://github.com/docker/docker-credential-helpers/releases/download/v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}/docker-credential-wincred-v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}.windows-{{ .chezmoi.arch }}.exe"
   executable: true
-  filter:
-    command: zcat
 
 "usr/local/share/gcm-core":
   type: archive
@@ -76,11 +73,10 @@
   exact: true
 
 {{   if .is_gnome }}
-"usr/bin":
-  type: archive
-  url: "https://github.com/docker/docker-credential-helpers/releases/download/v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}/docker-credential-secretservice-v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}-{{ .chezmoi.arch }}.tar.gz"
-  include:
-    - docker-credential-secretservice
+"usr/bin/docker-credential-secretservice":
+  type: file
+  url: "https://github.com/docker/docker-credential-helpers/releases/download/v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}/docker-credential-secretservice-v{{ template "get-github-latest-version" list "docker/docker-credential-helpers" $cache }}.linux-{{ .chezmoi.arch }}"
+  executable: true
 {{   end }}
 {{ end }}
 


### PR DESCRIPTION
- Revert "Pin docker credential helper to v0.6.4"
- Fix docker credential helper after 0.7.0
