### PR TITLE
Drop support for Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         variant: [devcontainer, wsl, gnome]
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         include:
           - variant: devcontainer
             os: alpine

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bootstrap your Ubuntu in a single command!
 
 ![Sample dotfiles image](https://user-images.githubusercontent.com/29582865/173688885-acd1e312-4741-4ec1-bc9d-b1f31e289749.png)
 
-This dotfiles repository is currently aimed for [**Ubuntu on WSL**](https://ubuntu.com/wsl), [**Ubuntu Server**](https://ubuntu.com/server), and [**Ubuntu Desktop**](https://ubuntu.com/desktop), tested against versions **18.04**, **20.04**, and **22.04**. See how to get started with WSL [here](https://docs.microsoft.com/pt-br/windows/wsl/install-win10).
+This dotfiles repository is currently aimed for [**Ubuntu on WSL**](https://ubuntu.com/wsl), [**Ubuntu Server**](https://ubuntu.com/server), and [**Ubuntu Desktop**](https://ubuntu.com/desktop), tested against versions **20.04** and **22.04**. See how to get started with WSL [here](https://docs.microsoft.com/pt-br/windows/wsl/install-win10).
 
 It's also suitable for use in [**GitHub Codespaces**](https://docs.github.com/codespaces/customizing-your-codespace/personalizing-codespaces-for-your-account#dotfiles), [**Gitpod**](https://www.gitpod.io/docs/config-dotfiles), [**VS Code Remote - Containers**](https://code.visualstudio.com/docs/remote/containers#_personalizing-with-dotfile-repositories), or even Linux distribution that are not Ubuntu, through the [**minimum mode**](#minimum-mode).
 

--- a/home/.chezmoiscripts/run_after_81-install-gnome-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/run_after_81-install-gnome-extensions.sh.tmpl
@@ -38,12 +38,7 @@ declare -A extension_codes
 
 extension_codes["user-theme@gnome-shell-extensions.gcampax.github.com"]=19
 extension_codes["dash-to-panel@jderose9.github.com"]=1160
-
-# {{ if eq .chezmoi.osRelease.versionCodename "bionic" }}
-extension_codes["arc-menu@linxgem33.com"]=1228
-# {{ else }}
 extension_codes["arcmenu@arcmenu.com"]=3628
-# {{ end }}
 
 missing_extensions=()
 

--- a/root/.chezmoiexternal.yaml
+++ b/root/.chezmoiexternal.yaml
@@ -40,15 +40,6 @@
   filter:
     command: gpg
     args: ["--dearmor"]
-
-{{   if eq .chezmoi.osRelease.versionCodename "bionic" }}
-"usr/share/keyrings/communitheme-ppa-archive-keyring.gpg":
-  type: file
-  url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xDEE9D5E11727231736FD173F03D12CDECFB24D48"
-  filter:
-    command: gpg
-    args: ["--dearmor"]
-{{   end }}
 {{ end }}
 
 "usr/local/bin/docker-compose":

--- a/root/.chezmoiignore
+++ b/root/.chezmoiignore
@@ -2,8 +2,6 @@
 etc/apt/sources.list.d/vscode.list
 etc/apt/sources.list.d/google-chrome.list
 etc/apt/sources.list.d/communitheme-ppa.list
-{{ else if not (eq .chezmoi.osRelease.versionCodename "bionic") }}
-etc/apt/sources.list.d/communitheme-ppa.list
 {{ end }}
 
 {{ if semverCompare ">20.04" .chezmoi.osRelease.versionID }}

--- a/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
@@ -34,11 +34,7 @@ readonly wanted_packages=(
   gnome-menus
   code
   google-chrome-stable
-  # {{   if eq .chezmoi.osRelease.versionCodename "bionic" }}
-  python-nautilus
-  # {{   else }}
   python3-nautilus
-  # {{   end }}
   # {{   if not .is_wsl }}
   yaru-theme-gnome-shell
   libsecret-1-0
@@ -48,9 +44,7 @@ readonly wanted_packages=(
   # {{ if .is_wsl }}
   wslu
   # {{ else }}
-  # {{   if eq .chezmoi.osRelease.versionCodename "bionic" }}
-  linux-generic-hwe-18.04
-  # {{   else if eq .chezmoi.osRelease.versionCodename "focal" }}
+  # {{   if eq .chezmoi.osRelease.versionCodename "focal" }}
   linux-generic-hwe-20.04
   # {{   end }}
   # {{ end }}

--- a/root/.chezmoiscripts/run_after_80-remove-files.sh.tmpl
+++ b/root/.chezmoiscripts/run_after_80-remove-files.sh.tmpl
@@ -11,10 +11,6 @@ true || source ../.chezmoitemplates/remove-files-library
 # https://github.com/twpayne/chezmoi/discussions/1789#discussioncomment-1920082
 
 readonly unwanted_files=(
-  # {{ if not (eq .chezmoi.osRelease.versionCodename "bionic") }}
-  /etc/apt/sources.list.d/communitheme-ppa.list
-  /usr/share/keyrings/communitheme-ppa-archive-keyring.gpg
-  # {{ end }}
   # {{ if not .is_gnome }}
   /usr/bin/docker-credential-secretservice
   # {{ end }}

--- a/root/.chezmoiscripts/run_before_30-uninstall-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_before_30-uninstall-apt-packages.sh.tmpl
@@ -10,9 +10,6 @@ readonly unwanted_packages=(
   direnv
   crudini
   fzf
-  # {{ if not (eq .chezmoi.osRelease.versionCodename "bionic") }}
-  python-nautilus
-  # {{ end }}
 )
 
 for package in "${unwanted_packages[@]}"; do

--- a/root/.chezmoiscripts/run_onchange_after_95-restart-docker-daemon.sh.tmpl
+++ b/root/.chezmoiscripts/run_onchange_after_95-restart-docker-daemon.sh.tmpl
@@ -10,7 +10,7 @@ true || source ../.chezmoitemplates/scripts-library
 log_task "Restarting Docker daemon"
 # {{ if .is_wsl }}
 # service restart fails if the service was never started
-c service docker restart || c service docker start
+c service docker restart || not_during_test c service docker start
 # {{ else }}
 c systemctl restart docker
 # {{ end }}

--- a/root/etc/apt/sources.list.d/communitheme-ppa.list.tmpl
+++ b/root/etc/apt/sources.list.d/communitheme-ppa.list.tmpl
@@ -1,1 +1,0 @@
-deb [signed-by=/usr/share/keyrings/communitheme-ppa-archive-keyring.gpg] http://ppa.launchpad.net/communitheme/ppa/ubuntu {{ .chezmoi.osRelease.ubuntuCodename }} main


### PR DESCRIPTION
It's almost 5 years old now, I don't use it, and the latest Node LTS doesn't support it either.