### PR TITLE
Add support for adding, removing, and updating `pkgx` packages

### DIFF
--- a/home/.chezmoiscripts/run_after_30-install-pkgx-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_after_30-install-pkgx-packages.sh.tmpl
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# {{ template "scripts-library" }}
+
+# The following line is for ShellCheck to correctly identify the above include
+true || source ../.chezmoitemplates/scripts-library
+
+ensure_path_entry "${HOME}/.local/bin"
+
+function is_pkgx_package_installed() {
+  local package="$1"
+
+  grep --quiet --recursive --binary-files=without-match --word-regexp \
+    "exec pkgx +${package}" "${HOME}/.local/bin"
+}
+
+readonly unwanted_packages=()
+
+for package in "${unwanted_packages[@]}"; do
+  # shellcheck disable=SC2310
+  if is_pkgx_package_installed "${package}"; then
+    log_task "Removing unwanted package '${package}' installed with pkgx"
+    {
+      grep --recursive --binary-files=without-match --files-with-matches \
+        --word-regexp "exec pkgx +${package}" "${HOME}/.local/bin" || true
+    } | xargs --no-run-if-empty rm -f
+  fi
+done
+
+readonly wanted_packages=(
+  opendev.org/git-review
+)
+
+missing_packages=()
+
+for package in "${wanted_packages[@]}"; do
+  # shellcheck disable=SC2310
+  if ! is_pkgx_package_installed "${package}"; then
+    missing_packages+=("${package}")
+  fi
+done
+
+if [[ ${#missing_packages[@]} -gt 0 ]]; then
+  log_task "Installing missing packages with pkgx: ${missing_packages[*]}"
+  pkgx install "${missing_packages[@]}"
+fi

--- a/home/dot_local/bin/executable_full-upgrade.tmpl
+++ b/home/dot_local/bin/executable_full-upgrade.tmpl
@@ -11,6 +11,8 @@ true || source ../../.chezmoitemplates/homebrew-library
 true || source ../../.chezmoitemplates/volta-library
 true || source ../../.chezmoitemplates/sdkman-library
 
+ensure_path_entry "${HOME}/.local/bin"
+
 if [[ "${CONTINUE_FROM_DOTFILES:-false}" == false ]]; then
   if brew --version &>/dev/null; then
     (
@@ -37,6 +39,57 @@ if [[ "${CONTINUE_FROM_DOTFILES:-false}" == false ]]; then
   fi
 
   CONTINUE_FROM_DOTFILES=true exec "$0" "$@"
+fi
+
+if pkgx --version >/dev/null; then
+  log_task "Updating pkgx stubs"
+
+  pkgx_packages="$(
+    {
+      grep --recursive --binary-files=without-match --no-filename \
+        --only-matching --perl-regexp --word-regexp \
+        'exec pkgx \+\K[^ ]+' "${HOME}/.local/bin" || true
+    } | sort --unique
+  )"
+
+  if [[ -z "${pkgx_packages}" ]]; then
+    log_info "No pkgx packages found"
+  else
+    readarray -t pkgx_packages <<<"${pkgx_packages}"
+
+    # This removes all the stubs directly as depending on the version of pkgx
+    # used to create the stub, pkgx uninstall can't uninstall it
+    {
+      grep --recursive --binary-files=without-match --files-with-matches \
+        --extended-regexp --word-regexp \
+        'exec pkgx \+[^ ]+' "${HOME}/.local/bin" || true
+    } | xargs --no-run-if-empty rm -f
+
+    # This updates the pantry, which would be updated automatically otherwise,
+    # but better safe than sorry
+    pkgx --sync >/dev/null
+
+    # And finally this adds all the stubs back, updated
+    pkgx install "${pkgx_packages[@]}"
+
+    log_task "Updating pkgx packages"
+
+    pkgx_packages_to_update=()
+    for package in "${pkgx_packages[@]}"; do
+      # This ensures we don't try to update packages that have not been cached
+      # yet, like the ones installed but never used
+      if [[ -d "${PKGX_DIR:-"${HOME}/.pkgx"}/${package}" ]]; then
+        pkgx_packages_to_update+=("+${package}")
+      fi
+    done
+
+    if [[ "${#pkgx_packages_to_update[@]}" -gt 0 ]]; then
+      c pkgx --update "${pkgx_packages_to_update[@]}" >/dev/null
+    fi
+
+    unset pkgx_packages_to_update
+  fi
+  unset pkgx_packages
 fi
 
 if apt --version &>/dev/null; then

--- a/home/dot_local/bin/executable_git-review
+++ b/home/dot_local/bin/executable_git-review
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec pkgx +opendev.org/git-review -- git-review "$@"


### PR DESCRIPTION
~Also use `gext` from `pkgx` rather than `pipx`. Since the `pipx install gnome-extensions-cli` only existed for a little while, I'm not adding code to automatically uninstall it.~ Not yet: https://github.com/pkgxdev/pantry/issues/5991#issuecomment-2081154003

Refs https://github.com/pkgxdev/pkgx/issues/985
Part of #101 