### PR TITLE
Install pipx using pyz

### DIFF
--- a/home/.chezmoiexternal.yaml
+++ b/home/.chezmoiexternal.yaml
@@ -69,6 +69,12 @@
 {{- end }}
 
 {{ if not .is_devcontainer -}}
+".local/bin/pipx":
+  type: file
+  {{ $pipxVersion := includeTemplate "get-github-latest-version" (list "pypa/pipx" $cache) }}
+  url: "https://github.com/pypa/pipx/releases/download/{{ $pipxVersion }}/pipx.pyz"
+  executable: true
+
 ".local/bin/kubecolor":
   type: archive-file
   {{ $kubecolorVersion := includeTemplate "get-github-latest-version" (list "kubecolor/kubecolor" $cache) }}

--- a/home/.chezmoiscripts/run_onchange_after_99-final-message.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_99-final-message.sh.tmpl
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# We need to install ca-certificates before we add the APT repos, because some of them
-# may use newer CAs.
-
 # {{ include (joinPath .chezmoi.sourceDir ".chezmoitemplates/scripts-library") }}
 
 # The following line is for ShellCheck to correctly identify the above included library

--- a/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
@@ -22,11 +22,8 @@ readonly wanted_packages=(
   git
   jq
   python3
-  # {{ if eq .chezmoi.osRelease.versionCodename "focal" }}
-  # pipx doesn't work otherwise
+  # needed by pipx
   python3-venv
-  # {{ end }}
-  pipx
   docker-ce
   docker-ce-cli
   containerd.io

--- a/root/.chezmoiscripts/run_before_30-uninstall-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_before_30-uninstall-apt-packages.sh.tmpl
@@ -14,11 +14,14 @@ readonly unwanted_packages=(
   skopeo
   # It is deprecated
   docker-scan-plugin
+  # It is now installed as a chezmoiexternal
+  pipx
 )
 
 for package in "${unwanted_packages[@]}"; do
+  # shellcheck disable=SC2310
   if is_apt_package_installed "${package}"; then
     log_task "Removing unwanted package '${package}' installed with APT"
-    c apt remove --yes "${package}"
+    c apt remove --yes --auto-remove "${package}"
   fi
 done

--- a/scripts/install_dotfiles.sh
+++ b/scripts/install_dotfiles.sh
@@ -78,7 +78,7 @@ DOTFILES_DIR="${HOME}/.dotfiles"
 if ! command -v git >/dev/null 2>&1; then
   log_task "Installing git"
   sudo apt update --yes
-  sudo apt install git --yes
+  sudo apt install --yes --no-install-recommends git
 fi
 
 if [ -d "${DOTFILES_DIR}" ]; then


### PR DESCRIPTION
Because pipx on Ubuntu 20.04 is outdated and does not function well.
