### PR TITLE
Improve Gerrit git aliases, adding support for % push options

### DIFF
--- a/home/.chezmoitemplates/get-github-head-revision
+++ b/home/.chezmoitemplates/get-github-head-revision
@@ -4,7 +4,7 @@
 {{- if hasKey $revisions $repo -}}
 {{-   get $revisions $repo -}}
 {{- else -}}
-{{-   $result := output "git" "ls-remote" (printf "https://github.com/%s.git" $repo) "HEAD" | trimSuffix "HEAD\n" | trim -}}
+{{-   $result := output "env" "GIT_CONFIG_GLOBAL=" "git" "ls-remote" (printf "https://github.com/%s.git" $repo) "HEAD" | trimSuffix "HEAD\n" | trim -}}
 {{-   $_ := set $revisions $repo $result -}}
 {{-   $result -}}
 {{- end -}}

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -37,10 +37,33 @@ path = ~/.config/gitalias/gitalias.txt
 caa = commit --amend --all
 caane = commit --amend --all --no-edit
 cob = checkout -b
-apply-gitignore = "!f() { set -ex; git rm -r --cached . >/dev/null; git add .; }; f"
-remote-for-branch = "!f() { set -ex; branch="${1:-"$(git current-branch)"}"; git rev-parse --abbrev-ref --symbolic-full-name "${branch}@{upstream}" | sed -n 's,^\\(\\S*\\)/'"${branch}"'$,\\1,p'; }; f"
-rr = "!f() { set -ex; branch="${1:-"$(git current-branch)"}"; remote="$(git remote-for-branch "${branch}")"; git reset --hard "${remote}/${branch}"; }; f"
-pfor = "!f() { set -ex; branch="${1:-"$(git current-branch)"}"; remote="$(git remote-for-branch "${branch}")"; git push "${remote}" "HEAD:refs/for/${branch}"; }; f"
-psfor = "!f() { set -ex; git caane; git pfor "$@"; }; f"
-pdraft = "!f() { set -ex; branch="${1:-"$(git current-branch)"}"; remote="$(git remote-for-branch "${branch}")"; git push "${remote}" "HEAD:refs/drafts/${branch}"; }; f"
-psdraft = "!f() { set -ex; git caane; git pdraft "$@"; }; f"
+apply-gitignore = "!f() { \
+  set -ex; \
+  git rm -r --cached . >/dev/null; \
+  git add .; \
+};f"
+remote-for-branch = "!f() { \
+  set -ex; \
+  branch="${1:-"$(git current-branch)"}"; \
+  git rev-parse --abbrev-ref --symbolic-full-name "${branch}@{upstream}" | sed -n 's,^\\(\\S*\\)/'"${branch}"'$,\\1,p' | grep .; \
+};f"
+rr = "!f() { \
+  set -ex; \
+  branch="${1:-"$(git current-branch)"}"; \
+  remote="$(git remote-for-branch "${branch}")"; \
+  git reset --hard "${remote}/${branch}"; \
+};f"
+pfor = "!f() { \
+  set -ex; \
+  branch="$(echo "${1}" | cut -d'%' -f1)"; \
+  branch="${branch:-"$(git current-branch)"}"; \
+  push_opts="$(echo "${1}" | cut -d'%' -f2-)"; \
+  push_opts="${push_opts:+"%${push_opts}"}"; \
+  remote="$(git remote-for-branch "${branch}")"; \
+  git push "${remote}" "HEAD:refs/for/${branch}${push_opts}"; \
+};f"
+psfor = "!f() { \
+  set -ex; \
+  git caane; \
+  git pfor "$@"; \
+};f"


### PR DESCRIPTION
Examples:

```console
$ git pfor %l=Code-Review+2,Verified+1
$ git pfor master%l=Code-Review+2,Verified+1
```

Also:

- Remove `git pdraft` alias which is a long-gone feature from Gerrit.
- Make `git remote-for-branch` fail if invalid branch
- Rewrite gitconfig using multi-line strings for better readability
- Make sure `git ls-remote` during `.chezmoiexternal.yaml` evaluation won't fail because of invalid gitconfig