### PR TITLE
Revamp APT lists handling

### DIFF
--- a/root/.chezmoiexternal.yaml
+++ b/root/.chezmoiexternal.yaml
@@ -3,43 +3,28 @@
 
 {{- template "read-versions-and-revisions-cache" $cache -}}
 
-"usr/share/keyrings/docker-archive-keyring.gpg":
+"usr/share/keyrings/docker.asc":
   type: file
   url: "https://download.docker.com/linux/{{ .chezmoi.osRelease.id }}/gpg"
-  filter:
-    command: gpg
-    args: ["--dearmor"]
 
-"usr/share/keyrings/git-core-ppa-archive-keyring.gpg":
+"usr/share/keyrings/git-core-ppa.asc":
   type: file
   url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF911AB184317630C59970973E363C90F8F1B6217"
-  filter:
-    command: gpg
-    args: ["--dearmor"]
 
 {{ if .is_wsl }}
-"usr/share/keyrings/wslu-ppa-archive-keyring.gpg":
+"usr/share/keyrings/wslu-ppa.asc":
   type: file
   url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x254F460F2970E18123046570C1D0E7E6AB4095D6"
-  filter:
-    command: gpg
-    args: ["--dearmor"]
 {{ end }}
 
 {{ if .is_gnome }}
-"usr/share/keyrings/microsoft.gpg":
+"usr/share/keyrings/microsoft.asc":
   type: file
   url: "https://packages.microsoft.com/keys/microsoft.asc"
-  filter:
-    command: gpg
-    args: ["--dearmor"]
 
-"usr/share/keyrings/google-chrome-archive-keyring.gpg":
+"usr/share/keyrings/google.asc":
   type: file
   url: "https://dl.google.com/linux/linux_signing_key.pub"
-  filter:
-    command: gpg
-    args: ["--dearmor"]
 {{ end }}
 
 "usr/local/bin/docker-compose":

--- a/root/.chezmoihooks/ensure-pre-requisites.sh
+++ b/root/.chezmoihooks/ensure-pre-requisites.sh
@@ -6,7 +6,8 @@
 set -eu
 
 wanted_packages=(
-  gpg # used to decrypt the gpg keys of the apt repositories
+  # None for now :-)
+  # TODO: consider removing this script
 )
 
 missing_packages=()

--- a/root/.chezmoiignore
+++ b/root/.chezmoiignore
@@ -1,4 +1,6 @@
 {{ if not .is_gnome }}
+etc/apt/sources.list.d/vscode-custom.list
+etc/apt/sources.list.d/google-chrome-custom.list
 etc/apt/sources.list.d/vscode.sources
 etc/apt/sources.list.d/google-chrome.list
 {{ end }}

--- a/root/.chezmoiremove
+++ b/root/.chezmoiremove
@@ -12,7 +12,13 @@ usr/local/share/gcm-core
 
 # Migrated to vscode.sources and microsoft.gpg
 etc/apt/sources.list.d/vscode.list
+
+# Migrated to .asc
+usr/share/keyrings/docker-archive-keyring.gpg
+usr/share/keyrings/git-core-ppa-archive-keyring.gpg
+usr/share/keyrings/wslu-ppa-archive-keyring.gpg
 usr/share/keyrings/vscode-archive-keyring.gpg
+usr/share/keyrings/google-chrome-archive-keyring.gpg
 
 # These files are known to be installed by Docker Desktop and they
 # conflict with the ones installed by APT.

--- a/root/etc/apt/sources.list.d/docker.list.tmpl
+++ b/root/etc/apt/sources.list.d/docker.list.tmpl
@@ -1,1 +1,1 @@
-deb [arch={{ .chezmoi.arch }} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/{{ .chezmoi.osRelease.id }} {{ .chezmoi.osRelease.versionCodename }} stable
+deb [arch={{ .chezmoi.arch }} signed-by=/usr/share/keyrings/docker.asc] https://download.docker.com/linux/{{ .chezmoi.osRelease.id }} {{ .chezmoi.osRelease.versionCodename }} stable

--- a/root/etc/apt/sources.list.d/git-core-ppa.list.tmpl
+++ b/root/etc/apt/sources.list.d/git-core-ppa.list.tmpl
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/git-core-ppa-archive-keyring.gpg] http://ppa.launchpad.net/git-core/ppa/ubuntu {{ .chezmoi.osRelease.ubuntuCodename }} main
+deb [signed-by=/usr/share/keyrings/git-core-ppa.asc] http://ppa.launchpad.net/git-core/ppa/ubuntu {{ .chezmoi.osRelease.ubuntuCodename }} main

--- a/root/etc/apt/sources.list.d/google-chrome-custom.list.tmpl
+++ b/root/etc/apt/sources.list.d/google-chrome-custom.list.tmpl
@@ -1,0 +1,1 @@
+deb [arch={{ .chezmoi.arch }} signed-by=/usr/share/keyrings/google.asc] https://dl.google.com/linux/chrome/deb/ stable main

--- a/root/etc/apt/sources.list.d/google-chrome.list.tmpl
+++ b/root/etc/apt/sources.list.d/google-chrome.list.tmpl
@@ -1,1 +1,0 @@
-deb [arch={{ .chezmoi.arch }} signed-by=/usr/share/keyrings/google-chrome-archive-keyring.gpg] https://dl.google.com/linux/chrome/deb/ stable main

--- a/root/etc/apt/sources.list.d/modify_google-chrome.list
+++ b/root/etc/apt/sources.list.d/modify_google-chrome.list
@@ -1,0 +1,17 @@
+{{- /* chezmoi:modify-template */ -}}
+
+{{- /* Comment out all non-empty and non-comment lines */ -}}
+{{- $result := list -}}
+{{- range splitList "\n" .chezmoi.stdin -}}
+{{-   if or (empty .) (hasPrefix "#" .) -}}
+{{-     $result = append $result . -}}
+{{-   else -}}
+{{-     $result = append $result (printf "# %s" .) -}}
+{{-   end -}}
+{{- end -}}
+{{- $result = join "\n" $result -}}
+
+{{- /* If there is no output, chezmoi deletes the file */ -}}
+{{- if trim $result -}}
+{{-   $result -}}
+{{- end -}}

--- a/root/etc/apt/sources.list.d/modify_vscode.sources
+++ b/root/etc/apt/sources.list.d/modify_vscode.sources
@@ -1,0 +1,17 @@
+{{- /* chezmoi:modify-template */ -}}
+
+{{- /* Comment out all non-empty and non-comment lines */ -}}
+{{- $result := list -}}
+{{- range splitList "\n" .chezmoi.stdin -}}
+{{-   if or (empty .) (hasPrefix "#" .) -}}
+{{-     $result = append $result . -}}
+{{-   else -}}
+{{-     $result = append $result (printf "# %s" .) -}}
+{{-   end -}}
+{{- end -}}
+{{- $result = join "\n" $result -}}
+
+{{- /* If there is no output, chezmoi deletes the file */ -}}
+{{- if trim $result -}}
+{{-   $result -}}
+{{- end -}}

--- a/root/etc/apt/sources.list.d/vscode-custom.list.tmpl
+++ b/root/etc/apt/sources.list.d/vscode-custom.list.tmpl
@@ -1,0 +1,1 @@
+deb [arch={{ .chezmoi.arch }} signed-by=/usr/share/keyrings/microsoft.asc] http://packages.microsoft.com/repos/code stable main

--- a/root/etc/apt/sources.list.d/vscode.sources
+++ b/root/etc/apt/sources.list.d/vscode.sources
@@ -1,8 +1,0 @@
-### THIS FILE IS AUTOMATICALLY CONFIGURED ###
-# You may comment out this entry, but any other modifications may be lost.
-Types: deb
-URIs: https://packages.microsoft.com/repos/code
-Suites: stable
-Components: main
-Architectures: amd64,arm64,armhf
-Signed-By: /usr/share/keyrings/microsoft.gpg

--- a/root/etc/apt/sources.list.d/wslu-ppa.list.tmpl
+++ b/root/etc/apt/sources.list.d/wslu-ppa.list.tmpl
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/wslu-ppa-archive-keyring.gpg] http://ppa.launchpad.net/wslutilities/wslu/ubuntu {{ .chezmoi.osRelease.ubuntuCodename }} main
+deb [signed-by=/usr/share/keyrings/wslu-ppa.asc] http://ppa.launchpad.net/wslutilities/wslu/ubuntu {{ .chezmoi.osRelease.ubuntuCodename }} main

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -179,7 +179,7 @@ for variant in "${variants[@]}"; do
 export IS_WSL=true
 
 # Exercises install-pre-requisites.sh
-sudo env DEBIAN_FRONTEND=noninteractive apt remove --yes --auto-remove zsh curl git gpg
+sudo env DEBIAN_FRONTEND=noninteractive apt remove --yes --auto-remove zsh curl git
 
 cat <<'EOM' | sudo tee /usr/local/bin/wslpath
 #!/usr/bin/env bash


### PR DESCRIPTION
1. All keyrings are now stored in `asc` extension because APT is able to read them. There's no longer a need to pass them through `gpg --dearmor`, which speeds up chezmoi external handling by a lot.
2. Google Chrome and VS Code APT original lists are now commented out rather than modified, and `google-chrome-custom.list` and `vscode-custom.list` will take place instead. This ensures updating these applications won't reset the modifications done in their APT lists.
3. `gpg` is no longer a pre-requisite, which is great news. Now there's no more pre-requisites, and I will consider removing the pre-requisites script in the future.