### PR TITLE
Replace pipx with uv and uvx

### DIFF
--- a/home/.chezmoiexternal.yaml
+++ b/home/.chezmoiexternal.yaml
@@ -65,11 +65,18 @@
 {{- end }}
 
 {{ if not .is_devcontainer -}}
-".local/bin/pipx":
-  type: file
-  {{ $pipxVersion := includeTemplate "get-github-latest-version" "pypa/pipx" }}
-  url: "https://github.com/pypa/pipx/releases/download/{{ $pipxVersion }}/pipx.pyz"
-  executable: true
+".local/bin/uv":
+  type: archive-file
+  {{ $uvVersion := includeTemplate "get-github-latest-version" "astral-sh/uv" }}
+  url: "https://github.com/astral-sh/uv/releases/download/{{ $uvVersion }}/uv-{{ .uname_arch }}-unknown-linux-gnu.tar.gz"
+  stripComponents: 1
+  path: uv
+
+".local/bin/uvx":
+  type: archive-file
+  url: "https://github.com/astral-sh/uv/releases/download/{{ $uvVersion }}/uv-{{ .uname_arch }}-unknown-linux-gnu.tar.gz"
+  stripComponents: 1
+  path: uvx
 
 ".local/bin/kubecolor":
   type: archive-file

--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -27,6 +27,10 @@
 # now we use gext instead
 .local/bin/gnome-shell-extension-installer
 
+# now we use uv instead
+.local/bin/pipx
+.local/share/pipx
+
 # tea got renamed to pkgx
 .local/bin/tea
 .tea

--- a/home/.chezmoiscripts/run_after_81-install-gnome-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/run_after_81-install-gnome-extensions.sh.tmpl
@@ -7,6 +7,11 @@ true || source ../.chezmoitemplates/scripts-library
 
 ensure_path_entry "${HOME}/.local/bin"
 
+# TODO: install the .pyz instead after https://github.com/essembeh/gnome-extensions-cli/issues/40
+function gext() {
+  uvx gnome-extensions-cli "$@"
+}
+
 function is_gnome_extension_installed() {
   local extension="$1"
 
@@ -42,11 +47,6 @@ disabled_extensions=(
 )
 
 missing_extensions=()
-
-if ! command -v gext >/dev/null; then
-  log_task "Installing gnome-extensions-cli"
-  c pipx install --force gnome-extensions-cli
-fi
 
 for extension in "${wanted_extensions[@]}"; do
   # shellcheck disable=SC2310

--- a/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
@@ -24,8 +24,6 @@ readonly wanted_packages=(
   git
   jq
   python3
-  # needed by pipx
-  python3-venv
   docker-ce
   docker-ce-cli
   containerd.io


### PR DESCRIPTION
[uv](https://github.com/astral-sh/uv) is awesome.

1. `uv pip` replaces `pip`
2. `uv venv` replaces `venv`
3. `uv tool` replaces `pipx`
4. `uvx` is like `npx` but for PyPA