### PR TITLE
Prefer bind9-dnsutils over dnsutils

### DIFF
--- a/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_after_10-install-apt-packages.sh.tmpl
@@ -31,7 +31,7 @@ readonly wanted_packages=(
   docker-buildx-plugin
   asciinema
   # provides nslookup
-  dnsutils
+  bind9-dnsutils
   # {{ if .is_gnome }}
   yaru-theme-gtk
   yaru-theme-icon

--- a/root/.chezmoiscripts/run_before_30-uninstall-apt-packages.sh.tmpl
+++ b/root/.chezmoiscripts/run_before_30-uninstall-apt-packages.sh.tmpl
@@ -16,6 +16,8 @@ readonly unwanted_packages=(
   docker-scan-plugin
   # It is now installed as a chezmoiexternal
   pipx
+  # Replaced by bind9-dnsutils
+  dnsutils
 )
 
 for package in "${unwanted_packages[@]}"; do


### PR DESCRIPTION
Because in Ubuntu 24.04, the package `dnsutils` has been replaced by `bind9-dnsutils`.